### PR TITLE
Implement simple API and web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# aws_demo
-aws_demo
+# AWS & OpenAI Image Extraction Demo
+
+Diese Demo automatisiert die Analyse und Informations-Extraktion aus Bildern mithilfe von AWS Lambda, OpenAI und Amazon S3.
+
+## Architektur
+
+- **Amazon S3**: Speicherung der Bilder, Ergebnisse und der kleinen Weboberfläche
+- **AWS Lambda**: Bildverarbeitung und API-Endpunkt
+- **API Gateway**: HTTP-API für Upload und Ergebnisausgabe
+- **OpenAI API**: Bildanalyse und Informations-Extraktion
+- **AWS Secrets Manager**: Sicherer Speicher für den OpenAI API Key
+
+## Deployment
+
+1. AWS CLI konfigurieren
+2. OpenAI API Key beim Ausführen des Skripts angeben und Deployment starten:
+   ```bash
+   ./scripts/deploy.sh
+   ```
+   Das Skript paketiert die Lambda-Funktionen und deployed den CloudFormation-Stack.
+   Nach erfolgreichem Deploy wird die API-Endpunkt-URL ausgegeben.
+
+## Nutzung
+
+Die minimale Weboberfläche befindet sich in `web/index.html`. Dort die Platzhalter-URL `REPLACE_WITH_API_ENDPOINT` durch die ausgegebene API-URL ersetzen und die Datei im Browser öffnen. Ein Bild kann anschließend hochgeladen werden und nach der Verarbeitung erscheint das JSON-Ergebnis auf der Seite.

--- a/cloudformation-template.yml
+++ b/cloudformation-template.yml
@@ -1,0 +1,174 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS Lambda and OpenAI Image Extraction Pipeline
+
+Parameters:
+  OpenAIAPIKey:
+    Type: String
+    NoEcho: true
+    Description: Dein OpenAI API Key
+
+Resources:
+  InputBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub 'openai-image-input-${AWS::AccountId}-${AWS::Region}'
+
+  OutputBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub 'openai-image-output-${AWS::AccountId}-${AWS::Region}'
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: 
+                  - !Sub '${InputBucket.Arn}/*'
+                  - !Sub '${OutputBucket.Arn}/*'
+              - Effect: Allow
+                Action: 
+                  - secretsmanager:GetSecretValue
+                Resource: '*'
+              - Effect: Allow
+                Action: logs:*
+                Resource: 'arn:aws:logs:*:*:*'
+
+  LambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: openai-image-extraction-function
+      Runtime: python3.12
+      Handler: lambda_function.lambda_handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Timeout: 60
+      MemorySize: 512
+      Environment:
+        Variables:
+          OUTPUT_BUCKET: !Ref OutputBucket
+          OPENAI_SECRET_NAME: openai/api/key
+      Code:
+        S3Bucket: !Ref InputBucket
+        S3Key: lambda-code.zip
+
+  LambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref LambdaFunction
+      Action: lambda:InvokeFunction
+      Principal: s3.amazonaws.com
+      SourceArn: !GetAtt InputBucket.Arn
+
+  BucketNotification:
+    Type: AWS::S3::BucketNotification
+    Properties:
+      Bucket: !Ref InputBucket
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Function: !GetAtt LambdaFunction.Arn
+
+  OpenAISecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: openai/api/key
+      SecretString: !Ref OpenAIAPIKey
+
+  ApiLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: openai-image-api
+      Runtime: python3.12
+      Handler: api_handler.lambda_handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Timeout: 60
+      MemorySize: 128
+      Environment:
+        Variables:
+          INPUT_BUCKET: !Ref InputBucket
+          OUTPUT_BUCKET: !Ref OutputBucket
+      Code:
+        S3Bucket: !Ref InputBucket
+        S3Key: api-code.zip
+
+  ApiLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref ApiLambdaFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+
+  ApiGateway:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: ImageApi
+      ProtocolType: HTTP
+
+  ApiGatewayIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref ApiGateway
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ApiLambdaFunction.Arn}/invocations
+      PayloadFormatVersion: '2.0'
+
+  ApiGatewayRouteUpload:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'POST /upload'
+      Target: !Sub integrations/${ApiGatewayIntegration}
+
+  ApiGatewayRouteResult:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref ApiGateway
+      RouteKey: 'GET /result/{proxy+}'
+      Target: !Sub integrations/${ApiGatewayIntegration}
+
+  ApiGatewayStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref ApiGateway
+      StageName: '$default'
+      AutoDeploy: true
+
+  WebBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      WebsiteConfiguration:
+        IndexDocument: index.html
+
+  WebBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref WebBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub '${WebBucket.Arn}/*'
+
+Outputs:
+  ApiEndpoint:
+    Value: !Sub 'https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com'
+    Description: API Endpoint URL
+  WebsiteURL:
+    Value: !GetAtt WebBucket.WebsiteURL
+    Description: URL der Weboberfläche

--- a/lambda/api_handler.py
+++ b/lambda/api_handler.py
@@ -1,0 +1,39 @@
+import boto3
+import os
+import json
+import base64
+import uuid
+
+s3 = boto3.client('s3')
+INPUT_BUCKET = os.environ['INPUT_BUCKET']
+OUTPUT_BUCKET = os.environ['OUTPUT_BUCKET']
+
+def lambda_handler(event, context):
+    route = event.get('rawPath', '')
+    method = event.get('requestContext', {}).get('http', {}).get('method', '')
+
+    if method == 'POST' and route == '/upload':
+        body = json.loads(event.get('body', '{}'))
+        filename = body.get('filename', 'upload')
+        file_data = base64.b64decode(body.get('file', ''))
+        key = f"{uuid.uuid4()}-{filename}"
+        s3.put_object(Bucket=INPUT_BUCKET, Key=key, Body=file_data)
+        return {
+            'statusCode': 200,
+            'headers': {'Content-Type': 'application/json'},
+            'body': json.dumps({'key': key})
+        }
+    elif method == 'GET' and route.startswith('/result/'):
+        key = route[len('/result/'):]
+        try:
+            response = s3.get_object(Bucket=OUTPUT_BUCKET, Key=f"{key}.json")
+            content = response['Body'].read().decode('utf-8')
+            return {
+                'statusCode': 200,
+                'headers': {'Content-Type': 'application/json'},
+                'body': content
+            }
+        except s3.exceptions.NoSuchKey:
+            return {'statusCode': 404, 'body': 'Not ready'}
+
+    return {'statusCode': 404, 'body': 'Not found'}

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,51 @@
+import boto3
+import openai
+import os
+import json
+import base64
+
+secrets_client = boto3.client('secretsmanager')
+s3 = boto3.client('s3')
+
+def get_openai_key(secret_name):
+    secret_response = secrets_client.get_secret_value(SecretId=secret_name)
+    secret = secret_response['SecretString']
+    return secret
+
+openai.api_key = get_openai_key(os.environ['OPENAI_SECRET_NAME'])
+
+def lambda_handler(event, context):
+    bucket = event['Records'][0]['s3']['bucket']['name']
+    key = event['Records'][0]['s3']['object']['key']
+
+    response = s3.get_object(Bucket=bucket, Key=key)
+    image_data = response['Body'].read()
+    image_base64 = base64.b64encode(image_data).decode('utf-8')
+
+    openai_response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Extrahiere alle relevanten Informationen aus diesem Bild."},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_base64}"}}
+                ]
+            }
+        ],
+        max_tokens=500
+    )
+
+    extracted_info = openai_response.choices[0].message.content
+
+    output_bucket = os.environ['OUTPUT_BUCKET']
+    output_key = key.rsplit('.', 1)[0] + '.json'
+
+    s3.put_object(
+        Bucket=output_bucket,
+        Key=output_key,
+        Body=json.dumps({"extracted_info": extracted_info}),
+        ContentType='application/json'
+    )
+
+    return {'statusCode': 200}

--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+openai

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+STACK_NAME="openai-image-extraction-stack"
+
+# prepare lambda packages
+cd lambda
+pip install -r requirements.txt -t ./package
+zip -r ../lambda-code.zip lambda_function.py package > /dev/null
+zip -r ../api-code.zip api_handler.py package > /dev/null
+cd ..
+
+# deploy stack
+aws cloudformation deploy \
+  --stack-name $STACK_NAME \
+  --template-file cloudformation-template.yml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides OpenAIAPIKey=${OPENAI_KEY}
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region)
+INPUT_BUCKET="openai-image-input-${ACCOUNT_ID}-${REGION}"
+WEB_BUCKET=$(aws cloudformation describe-stack-resources --stack-name $STACK_NAME --logical-resource-id WebBucket --query 'StackResources[0].PhysicalResourceId' --output text)
+
+aws s3 cp lambda-code.zip s3://$INPUT_BUCKET/lambda-code.zip
+aws s3 cp api-code.zip s3://$INPUT_BUCKET/api-code.zip
+aws s3 cp web/index.html s3://$WEB_BUCKET/index.html --content-type text/html
+
+echo "Deployment abgeschlossen."

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <title>Image Extraction Demo</title>
+</head>
+<body>
+  <h1>Bild hochladen</h1>
+  <input type="file" id="fileInput" />
+  <button id="uploadBtn">Hochladen</button>
+  <pre id="output"></pre>
+  <script>
+    const API_BASE = 'REPLACE_WITH_API_ENDPOINT';
+    const fileInput = document.getElementById('fileInput');
+    document.getElementById('uploadBtn').onclick = async () => {
+      const file = fileInput.files[0];
+      if (!file) return alert('Bitte Datei wählen');
+      const reader = new FileReader();
+      reader.onload = async () => {
+        const b64 = reader.result.split(',')[1];
+        const res = await fetch(`${API_BASE}/upload`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filename: file.name, file: b64 })
+        });
+        const data = await res.json();
+        pollResult(data.key);
+      };
+      reader.readAsDataURL(file);
+    };
+
+    async function pollResult(key) {
+      let done = false;
+      while (!done) {
+        await new Promise(r => setTimeout(r, 3000));
+        const res = await fetch(`${API_BASE}/result/${key}`);
+        if (res.ok) {
+          const out = await res.json();
+          document.getElementById('output').textContent = JSON.stringify(out, null, 2);
+          done = true;
+        }
+      }
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rewrite README with instructions for simple web interface
- extend CloudFormation template with API Gateway, Lambda, and website bucket
- add API Lambda handler for uploads and result retrieval
- create HTML page for uploading images and showing output
- update deployment script to package lambdas and upload website

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ee92f89083228fc23dcef7a7f0fd